### PR TITLE
Don't import unicode.strip, ospaths.

### DIFF
--- a/core/consts.nim
+++ b/core/consts.nim
@@ -1,5 +1,5 @@
 import
-  ospaths
+  os
 
 const
   pkgName*        = "min"

--- a/core/interpreter.nim
+++ b/core/interpreter.nim
@@ -4,7 +4,6 @@ import
   critbits, 
   os,
   algorithm,
-  ospaths,
   times,
   logging
 import 

--- a/core/parser.nim
+++ b/core/parser.nim
@@ -4,11 +4,12 @@ import
   sequtils,
   strutils, 
   streams, 
-  unicode, 
   tables,
   critbits,
   math,
   logging
+ 
+import unicode except strip
 
 type
   MinTokenKind* = enum

--- a/min.nim
+++ b/min.nim
@@ -6,7 +6,6 @@ import
   parseopt, 
   strutils, 
   os, 
-  ospaths,
   json, 
   sequtils,
   algorithm,


### PR DESCRIPTION
This fixes compilation and deprecation warnings on `devel`.