### PR TITLE
Added Release action for GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
+    tags-ignore: [ '**' ]
   pull_request:
     branches: [ master ]
+    tags-ignore: [ '**' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,9 @@ name: Release
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:
+      - 'v*.*.*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 # Controls when the action will run. 
 on:
+  # Run only when a new tag is pushed
   push:
     tags:
       - 'v*.*.*'
@@ -9,13 +10,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "ci"
+
+  # First, build and package our different assets
   package:
     name: "Package"
 
-    # The type of runner that the job will run on
+    # Set up a matrix of different configurations:
+    # for now Linux and MacOS (Windows can obviously be added as well)
+    # Here, we could also add flags - under a different matrix key - 
+    # for different builds: e.g. lite vs non-lite
+      
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,71 +32,88 @@ jobs:
       CHOOSENIM_CHOOSE_VERSION: stable
       CHOOSENIM_NO_ANALYTICS: 1
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Cancel other actions of the same type that might be already running
+    
       - name: "Cancel similar actions in progress"
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ github.token }}
 
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks out the repository
       - uses: actions/checkout@v2
       
+      # Install libraries
       - name: install musl-gcc
         run: sudo apt-get install -y musl-tools 
         if: matrix.os == 'ubuntu-latest'
       
+      # Set path
       - name: Update $PATH
         run: echo "$HOME/.nimble/bin" >> $GITHUB_PATH
 
+      # Install the compiler
       - name: Install Nim
         run: |
           curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
           sh init.sh -y
 
+      # Install dependencies
       - name: Install nifty
         run: nimble install -y nifty
         
       - name: Install deps
         run: nifty install
       
+      # Build for linux
       - name: Build (Linux)
         run: nim c -d:release -d:ssl --gcc.exe:musl-gcc --gcc.linkerexe:musl-gcc --cpu:amd64 --os:linux  -o:min min
         if: matrix.os == 'ubuntu-latest'
 
+      # Build for MacOS
       - name: Build (MacOS)
         run: nim c -d:release -d:ssl -o:min min
         if: matrix.os == 'macos-latest'
       
+      # Package the resulting binary (along with the license and readme file)
       - name: Create artifact
         run: |
           install -m 0755 ./min .
           tar czf min-${{runner.os}}.tar.gz min README.md LICENSE
 
+      # And upload it, so that we can reuse all of them later as release assets
       - name: Upload Artifact
         uses: 'actions/upload-artifact@v1'
         with:
           name: min-${{runner.os}}.tar.gz
           path: min-${{runner.os}}.tar.gz
           
+  # Then, let's prepare our new release and upload the assets above
   upload:
     name: "Upload"
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    
+    # This should run after all matrix job (for linux, mac, etc) above have finished
     needs: [package]
+    
     steps:
       - name: "Cancel similar actions in progress"
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ github.token }}
 
+      # Download all of the previously created assets 
+      # and put them in an ./assets folder
       - uses: actions/download-artifact@v2
         with:
           path: ./assets
       
+      # That's just for debugging to make sure everything is in place
       - name: Display structure of downloaded files
         run: ls -R
 
+      # Create a new release
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1
@@ -105,6 +127,8 @@ jobs:
           draft: false
           prerelease: false
 
+      # Post all of the above assets (under ./assets) 
+      # as part of the newly created release
       - name: Upload Release Assets
         id: upload-release-assets
         uses: dwenegar/upload-release-assets@v1
@@ -113,3 +137,5 @@ jobs:
         with:
           release_id: ${{ steps.create-release.outputs.id }}
           assets_path: ./assets
+
+      # Celebrate! :)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,13 @@ jobs:
         run: nim c -d:release -d:ssl -o:min min
         if: matrix.os == 'macos-latest'
       
-      
+      - name: Create artifact
+        run: |
+          install -m 0755 ./min .
+          tar czf min-${{runner.os}}.tar.gz min README.md LICENSE
+
+      - name: Upload Artifact
+        uses: 'actions/upload-artifact@v1'
+        with:
+          name: min-${{runner.os}}.tar.gz
+          path: min-${{runner.os}}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "ci"
+  package:
+    name: "Package"
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    env:
+      CHOOSENIM_CHOOSE_VERSION: stable
+      CHOOSENIM_NO_ANALYTICS: 1
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: "Cancel similar actions in progress"
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: install musl-gcc
+        run: sudo apt-get install -y musl-tools 
+        if: matrix.os == 'ubuntu-latest'
+      
+      - name: Update $PATH
+        run: echo "$HOME/.nimble/bin" >> $GITHUB_PATH
+
+      - name: Install Nim
+        run: |
+          curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+          sh init.sh -y
+
+      - name: Install nifty
+        run: nimble install -y nifty
+        
+      - name: Install deps
+        run: nifty install
+      
+      - name: Build (Linux)
+        run: nim c -d:release -d:ssl --gcc.exe:musl-gcc --gcc.linkerexe:musl-gcc --cpu:amd64 --os:linux  -o:min min
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Build (MacOS)
+        run: nim c -d:release -d:ssl -o:min min
+        if: matrix.os == 'macos-latest'
+      
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,43 @@ jobs:
         with:
           name: min-${{runner.os}}.tar.gz
           path: min-${{runner.os}}.tar.gz
+          
+  upload:
+    name: "Upload"
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [package]
+    steps:
+      - name: "Cancel similar actions in progress"
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/download-artifact@v2
+        with:
+          path: ./assets
+      
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        id: upload-release-assets
+        uses: dwenegar/upload-release-assets@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create-release.outputs.id }}
+          assets_path: ./assets


### PR DESCRIPTION
Since [we were talking about it](https://github.com/h3rald/min/discussions/97) and I've ended up spending over 4 hours [trying to make it work for Arturo](https://github.com/arturo-lang/arturo/releases/tag/v0.9.6), I've though of just posting [a link of how I did it.](https://github.com/arturo-lang/arturo/releases/tag/v0.9.6)

But then, I thought: why not do it myself - or at least start it - and make a PR? :)

So... Tell me what you think! 

P.S. I'm not sure it works 100%, since I don't know the internals of min or its compilation (I haven't taken into account *lite* releases), but - given that I was based on your CI workflow and the work I did earlier on Arturo, it should be working (or after minimal effort...)