### PR TITLE
Added Dockerfile (min Docker image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# use Alpine+Nim as a basis 
+FROM frolvlad/alpine-nim
+
+# install necessary packages
+RUN apk update
+RUN apk add curl git
+
+# clone repository
+RUN git clone https://github.com/h3rald/min.git
+
+# install nifty
+RUN nimble install -y nifty
+
+# set path to nifty
+# (for some reason it doesn't pick it up by itself)
+ENV PATH="/root/.nimble/pkgs/nifty-1.2.2:${PATH}"
+
+# install dependencies with nifty
+RUN cd min && nifty install
+
+# build min
+RUN cd min && nim c -d:release -d:ssl -o:min min
+
+# set our PATH to the min's location
+ENV PATH="/min:${PATH}"
+
+# set our workdir to /home
+# (where our local files will be mirrored)
+WORKDIR /home
+
+# start up the main binary 
+ENTRYPOINT [ "/min/min" ]


### PR DESCRIPTION
Basically, the code is very straightforward:

- it creates an image with Alpine Linux + Nim pre-installed (basically, the most lightweight setup)
- installs the dependencies (packages + Nim libraries)
- clones the min repo
- builds it
- points to the resulting binary

You can build the image locally with: 

```bash
docker build -t mindocker .
```

And run it with:

```bash
docker run -it mindocker
```

Of course you could also mirror the repo at Docker Hub so that anyone could easily launch the min REPL without needing to know anything about min or its dependencies, like:

```bash
docker run -it minlang/min
```

or even run a script directly:

```bash
docker run -it -v $(pwd):/home minlang/min <PATH_TO_LOCAL_SCRIPT.min>
```