### PR TITLE
Add `range` function to Num library (+unit tests, +documentation)

### DIFF
--- a/minpkg/lib/min_num.nim
+++ b/minpkg/lib/min_num.nim
@@ -181,5 +181,27 @@ proc num_module*(i: In)=
           i.push ((first.intVal.float+second.floatVal)/2).newVal
         else:
           i.push ((first.intVal+second.intVal).float/2).newVal
+    
+  def.symbol("range") do (i: In):
+    var s: MinValue
+    i.reqQuotationOfNumbers s
+    var a = s.qVal[0]
+    var b = s.qVal[1]
+    var step = 1.newVal
+    var res = newSeq[MinValue](0)
+    if len(s.qVal)==3:
+      a = s.qVal[0]
+      b = s.qVal[1]
+      step = s.qVal[2]
+    var j = a
+    if a.intVal < b.intVal:
+      while j.intVal <= b.intVal:
+        res.add j
+        j = (j.intVal + step.intVal).newVal
+    else:
+      while j.intVal >= b.intVal:
+        res.add j
+        j = (j.intVal - step.intVal).newVal
+    i.push res.newVal
 
   def.finalize("num")

--- a/minpkg/lib/min_num.nim
+++ b/minpkg/lib/min_num.nim
@@ -160,7 +160,6 @@ proc num_module*(i: In)=
         c = + n.floatVal
       else:
         c = c + n.intVal.float
-    
     c = c / len(s.qVal).float
     i.push c.newVal
  

--- a/site/contents/reference-num.md
+++ b/site/contents/reference-num.md
@@ -65,3 +65,6 @@ Returns the average of the items of {{q}}. #}
 
 {#op||med||{{q}}||{{n}}||
 Returns the median of the items of {{q}}. #}
+
+{#op||range||{{q}}||{{q}}||
+Takes a quotation of integers in the form of {{start}}, {{end}} (,{{step}}), generates the sequence and returns the resulting quotation of integers. #}

--- a/tests/num.min
+++ b/tests/num.min
@@ -40,6 +40,17 @@
   ((1 3 5 7) med 4.0 ==) assert
   ((1 3 5 7 9) med 5 ==) assert
 
+  ((1 5) range (1 2 3 4 5) ==) assert
+  ((5 1) range (5 4 3 2 1) ==) assert
+  ((4 7) range (4 5 6 7) ==) assert
+  ((7 4) range (7 6 5 4) ==) assert
+  ((1 6 2) range (1 3 5) ==) assert
+  ((1 6 3) range (1 4) ==) assert
+  ((0 6 2) range (0 2 4 6) ==) assert
+  ((6 1 2) range (6 4 2) ==) assert
+  ((6 1 3) range (6 3) ==) assert
+  ((6 0 2) range (6 4 2 0) ==) assert
+  
   (0 :c
     (c 10 <) (c succ @c) while
     c 10 ==) assert


### PR DESCRIPTION
Exactly as we said :) #108 

The implementation covers an optional third element in the argument/quotation which may function as a `step`.
Also, it supports range regardless of the direction: if `a<b` it generates an *upwards* range, while if `a>=b` it generates a *downwards* range.

Here's the relevant part from the unit tests:

```
  ((1 5) range (1 2 3 4 5) ==) assert
  ((5 1) range (5 4 3 2 1) ==) assert
  ((4 7) range (4 5 6 7) ==) assert
  ((7 4) range (7 6 5 4) ==) assert
  ((1 6 2) range (1 3 5) ==) assert
  ((1 6 3) range (1 4) ==) assert
  ((0 6 2) range (0 2 4 6) ==) assert
  ((6 1 2) range (6 4 2) ==) assert
  ((6 1 3) range (6 3) ==) assert
  ((6 0 2) range (6 4 2 0) ==) assert
```